### PR TITLE
 Adds flush-cache and several minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,205 +20,8 @@ $ npm install machinepack-redis --save
 
 ## Quick Start
 
-The example below contains a ready-to-use function useful for obtaining one-off access to a Redis connection.
+The example in [examples/basic-usage.js](examples/basic-usage.js) contains a ready-to-use function useful for obtaining one-off access to a Redis connection.
 Under the covers, in the function's implementation, you can see how to manage the Redis connection lifecycle, as well as how to implement thorough, production-level (anal-retentive) error handling.
-
-```javascript
-
-/**
- * Module dependencies
- */
-var Redis = require('machinepack-redis');
-
-
-/**
- * doSomeStuffWithRedis()
- *
- * An example of a helper function you might write using mp-redis.
- *
- * @required {String} connectionString
- *   Connection string to use when connecting to Redis.
- *
- * @optional {Function} during
- *   Lifecycle callback to run once the connection is active.  Receives connection as first arg, and standard Node cb as second.
- *   Expected to call `during` when finished (at which point the connection is released).
- *
- * @optional {Function} onUnexpectedFailure
- *   Notifier function to run each time an unexpected failure notice is received one way or the other.
- *   Receives relevant Error as 1st argument.
- */
-function doSomeStuffWithRedis(opts, done) {
-  if (opts.connectionString === undefined) { return done(new Error('`connectionString` is required.')); }
-  if (opts.during !== undefined & typeof opts.during !== 'function') {
-    return done(new Error('If provided, `during` must be a function.'));
-  }
-  if (opts.onUnexpectedFailure !== undefined & typeof opts.onUnexpectedFailure !== 'function') {
-    return done(new Error('If provided, `onUnexpectedFailure` must be a function.'));
-  }
-  
-  Redis.createManager({
-    connectionString: opts.connectionString,
-    onUnexpectedFailure: function (err){
-      // Use custom notifier function, if one was provided.
-      if (opts.onUnexpectedFailure) {
-        opts.onUnexpectedFailure(err);
-        return;
-      }
-      //--• Otherwise, do the default thing (log a warning)
-      console.warn('WARNING: Redis manager emitted a notice about an unexpected failure.  The redis server may have crashed, or become inaccessible.  Error details from Redis:', err);
-    }
-  }).exec(function (err, report){
-    if (err) {
-      return done(new Error('Could not create manager due to unexpected error: '+ err.stack));
-    }//--• No reason to proceed any further.
-    
-    var mgr = report.manager;
-    Redis.getConnection({
-      manager: mgr
-    }).exec(function (err, report){
-      if (err) {
-        return done(new Error('Could not get connection from manager, due to unexpected error: '+err.stack));
-      }//--• No reason to proceed any further.
-      
-      // Local var for convenience.
-      var connection = report.connection;
-      
-      
-      console.log('CONNECTED!');
-      
-      // Now do stuff w/ the connection
-      (opts.during||function noOp(connection, proceed){
-        return proceed();
-      })(report.connection, function afterwards (err_doingStuff) {
-        if (err_doingStuff) {
-          console.log('Unexpected error occurred while doing stuff with this Redis connection.  Details: '+err_doingStuff.stack);
-          console.log('Nonetheless, continuing on to release the connection and destroy the manager....');
-        }// >- continue on to attempt to release the connection and destroy the manager.
-        
-        // Always release the connection when finished:
-        Redis.releaseConnection({
-          connection: connection
-        }).exec({
-          error: function (err_releaseConnection){
-            console.warn(new Error('Could not release Redis connection due to unexpected error: '+err_releaseConnection.stack));
-            // ^^Note that we might want to also still attempt to destroy the manager here, even
-            // though we couldn't release the connection. (However, we don't mess w/ that in this example code.)
-            
-            if (err_doingStuff) { return done(err_doingStuff); }
-            else {
-              console.warn('Triggering success callback anyway, since everything else seemed to work ok...');
-              return done();
-            }
-          },
-          success: function (report){
-            console.log('Connection released.');
-  
-            // But ALWAYS destroy the connection manager when finished
-            Redis.destroyManager({manager: mgr}).exec(function (err_destroyMgr){
-              if (err_destroyMgr) {
-                console.warn(new Error('Could not destroy Redis connection manager due to unexpected error: '+ err_destroyMgr.stack));
-                
-                if (err_doingStuff) { return done(err_doingStuff); }
-                else {
-                  console.warn('Triggering success callback anyway, since everything else seemed to work ok...');
-                  return done();
-                }
-              }//--•
-              
-              console.log('Manager destroyed.');
-              
-              // Now, depending on whether we ran into an error above, finish up accordingly.
-              if (err_doingStuff) {
-                // Encountered an error along the way, but at least cleanup worked out ok!
-                return done(err_doingStuff);
-              }
-              else {
-                // Done.  No errors, and we cleaned up everything successfully!
-                return done();
-              }
-              
-            }); //</Redis.destroyManager>
-  
-          }//</on success :: Redis.releaseConnection()>
-        });//</Redis.releaseConnection()>
-      });//</during (do stuff while redis connection is active)>
-    }); //</Redis.getConnection>
-  }); //</Redis.createManager>
-}//</declare :: doSomeStuffWithRedis()>
-
-
-// Then e.g. you can do:
-doSomeStuffWithRedis({
-  connectionString: 'redis://127.0.0.1:6379',
-  onUnexpectedFailure: function (err){ console.warn('uh oh, looks like our redis might have just gone down:',err); },
-  during: function (connection, proceed) {
-    
-    // Storing in key `stuff` value `things`
-    Redis.cacheValue({
-      connection: connection,
-      key: 'stuff',
-      value: 'things'
-    }).exec(function (err, report){
-      if (err) {
-        return proceed(new Error('Could not cache value, due to unexpected error.  Error details: '+err.stack));
-      }
-
-      console.log('stored `stuff` key with `things`');
-
-      // Get the cached value back
-      Redis.getCachedValue({
-        connection: connection,
-        key: 'stuff'
-      }).exec(function (err, report){
-        if (err) {
-          return proceed(new Error('Could not get cached value, due to unexpected error.  Error details:', err.stack));
-        }
-
-        console.log('stuff `key` contains `%s`', report.value);
-
-        // remove keys. Notice that keys is an array of keys to remove
-        Redis.destroyCachedValues({
-          connection: connection,
-          keys: ['stuff']
-        }).exec(function (err, report){
-          if (err) {
-            return proceed(new Error('Could not get destroy cached values, due to unexpected error.  Error details:', err.stack));
-          }
-
-          console.log('key `stuff` removed');
-
-          // Get the cached value back
-          Redis.getCachedValue({
-            connection: connection,
-            key: 'stuff'
-          }).exec({
-            error: function (err){
-              return proceed(new Error('Could not get cached value the 2nd time, due to unexpected error.  Error details:', err.stack));
-            },
-            notFound: function (){
-              console.log('As we expected, the `stuff` key was not found this time.  Good!');
-              return proceed();
-            },
-            success: function (){
-              return proceed(new Error('Consistency violation: Should not have been able to find `stuff` key the 2nd time!!!  Must be a bug in our code.'));
-            }
-          }); //</Redis.getCachedValue>
-
-        }); //</Redis.destroyCachedValues>
-      }); //</Redis.getCachedValue>
-    }); //</Redis.cacheValue>
-  }//</during>
-  
-}, function afterwards(err) {
-  if (err) {
-    console.log('Attempted to do some stuff with redis, but encountered an error along the way:',err.stack);
-    return;
-  }//--•
-  
-  console.log('Successfully did some stuff with Redis!');
-});
-```
-
 
 > ##### Setup instructions for the example above
 > 
@@ -227,14 +30,8 @@ doSomeStuffWithRedis({
 > redis-server
 > ```
 > 
-> Next, copy the example code below to a new `.js` file somewhere in your project (e.g. `examples/basic-usage.js`).
-> Then run:
-> ```bash
-> npm install machinepack-redis --save --save-exact
-> ```
+> Asuming that you cloned the module, you can just run the example:
 >
->
-> Finally, run the example:
 > ```bash
 > node examples/basic-usage.js
 > ```
@@ -255,5 +52,5 @@ Learn more at <a href="http://node-machine.org/implementing/FAQ" title="Machine 
 
 ## License
 
-MIT &copy; 2015 contributors
+MIT &copy; 2015, 2016 contributors
 

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -1,0 +1,194 @@
+/**
+ * Module dependencies
+ */
+var Redis = require('../');
+
+
+/**
+ * doSomeStuffWithRedis()
+ *
+ * An example of a helper function you might write using mp-redis.
+ *
+ * @required {String} connectionString
+ *   Connection string to use when connecting to Redis.
+ *
+ * @optional {Function} during
+ *   Lifecycle callback to run once the connection is active.  Receives connection as first arg, and standard Node cb as second.
+ *   Expected to call `during` when finished (at which point the connection is released).
+ *
+ * @optional {Function} onUnexpectedFailure
+ *   Notifier function to run each time an unexpected failure notice is received one way or the other.
+ *   Receives relevant Error as 1st argument.
+ */
+function doSomeStuffWithRedis(opts, done) {
+  if (opts.connectionString === undefined) { return done(new Error('`connectionString` is required.')); }
+  if (opts.during !== undefined & typeof opts.during !== 'function') {
+    return done(new Error('If provided, `during` must be a function.'));
+  }
+  if (opts.onUnexpectedFailure !== undefined & typeof opts.onUnexpectedFailure !== 'function') {
+    return done(new Error('If provided, `onUnexpectedFailure` must be a function.'));
+  }
+  
+  Redis.createManager({
+    connectionString: opts.connectionString,
+    onUnexpectedFailure: function (err){
+      // Use custom notifier function, if one was provided.
+      if (opts.onUnexpectedFailure) {
+        opts.onUnexpectedFailure(err);
+        return;
+      }
+      //--• Otherwise, do the default thing (log a warning)
+      console.warn('WARNING: Redis manager emitted a notice about an unexpected failure.  The redis server may have crashed, or become inaccessible.  Error details from Redis:', err);
+    }
+  }).exec(function (err, report){
+    if (err) {
+      return done(new Error('Could not create manager due to unexpected error: '+ err.stack));
+    }//--• No reason to proceed any further.
+    
+    var mgr = report.manager;
+    Redis.getConnection({
+      manager: mgr
+    }).exec(function (err, report){
+      if (err) {
+        return done(new Error('Could not get connection from manager, due to unexpected error: '+err.stack));
+      }//--• No reason to proceed any further.
+      
+      // Local var for convenience.
+      var connection = report.connection;
+      
+      
+      console.log('CONNECTED!');
+      
+      // Now do stuff w/ the connection
+      (opts.during||function noOp(connection, proceed){
+        return proceed();
+      })(report.connection, function afterwards (err_doingStuff) {
+        if (err_doingStuff) {
+          console.log('Unexpected error occurred while doing stuff with this Redis connection.  Details: '+err_doingStuff.stack);
+          console.log('Nonetheless, continuing on to release the connection and destroy the manager....');
+        }// >- continue on to attempt to release the connection and destroy the manager.
+        
+        // Always release the connection when finished:
+        Redis.releaseConnection({
+          connection: connection
+        }).exec({
+          error: function (err_releaseConnection){
+            console.warn(new Error('Could not release Redis connection due to unexpected error: '+err_releaseConnection.stack));
+            // ^^Note that we might want to also still attempt to destroy the manager here, even
+            // though we couldn't release the connection. (However, we don't mess w/ that in this example code.)
+            
+            if (err_doingStuff) { return done(err_doingStuff); }
+            else {
+              console.warn('Triggering success callback anyway, since everything else seemed to work ok...');
+              return done();
+            }
+          },
+          success: function (report){
+            console.log('Connection released.');
+  
+            // But ALWAYS destroy the connection manager when finished
+            Redis.destroyManager({manager: mgr}).exec(function (err_destroyMgr){
+              if (err_destroyMgr) {
+                console.warn(new Error('Could not destroy Redis connection manager due to unexpected error: '+ err_destroyMgr.stack));
+                
+                if (err_doingStuff) { return done(err_doingStuff); }
+                else {
+                  console.warn('Triggering success callback anyway, since everything else seemed to work ok...');
+                  return done();
+                }
+              }//--•
+              
+              console.log('Manager destroyed.');
+              
+              // Now, depending on whether we ran into an error above, finish up accordingly.
+              if (err_doingStuff) {
+                // Encountered an error along the way, but at least cleanup worked out ok!
+                return done(err_doingStuff);
+              }
+              else {
+                // Done.  No errors, and we cleaned up everything successfully!
+                return done();
+              }
+              
+            }); //</Redis.destroyManager>
+  
+          }//</on success :: Redis.releaseConnection()>
+        });//</Redis.releaseConnection()>
+      });//</during (do stuff while redis connection is active)>
+    }); //</Redis.getConnection>
+  }); //</Redis.createManager>
+}//</declare :: doSomeStuffWithRedis()>
+
+
+// Then e.g. you can do:
+doSomeStuffWithRedis({
+  // [redis:]//[[user][:password]@][host][:port][/db-number][?db=db-number[&password=bar[&option=value]]] 
+  connectionString: 'redis://127.0.0.1:6379/14', // 14 is the selected redis database
+  onUnexpectedFailure: function (err){ console.warn('uh oh, looks like our redis might have just gone down:',err); },
+  during: function (connection, proceed) {
+    
+    // Storing in key `stuff` value `things`
+    Redis.cacheValue({
+      connection: connection,
+      key: 'stuff',
+      value: 'things'
+    }).exec(function (err, report){
+      if (err) {
+        return proceed(new Error('Could not cache value, due to unexpected error.  Error details: '+err.stack));
+      }
+
+      console.log('stored `stuff` key with `things`');
+
+      // Get the cached value back
+      Redis.getCachedValue({
+        connection: connection,
+        key: 'stuff'
+      }).exec(function (err, report){
+        if (err) {
+          return proceed(new Error('Could not get cached value, due to unexpected error.  Error details:', err.stack));
+        }
+
+        console.log('stuff `key` contains `%s`', report.value);
+
+        // remove keys. Notice that keys is an array of keys to remove
+        Redis.destroyCachedValues({
+          connection: connection,
+          keys: ['stuff']
+        }).exec(function (err, report){
+          if (err) {
+            return proceed(new Error('Could not get destroy cached values, due to unexpected error.  Error details:', err.stack));
+          }
+
+          console.log('key `stuff` removed');
+
+          // Get the cached value back
+          Redis.getCachedValue({
+            connection: connection,
+            key: 'stuff'
+          }).exec({
+            error: function (err){
+              return proceed(new Error('Could not get cached value the 2nd time, due to unexpected error.  Error details:', err.stack));
+            },
+            notFound: function (){
+              console.log('As we expected, the `stuff` key was not found this time.  Good!');
+              return proceed();
+            },
+            success: function (){
+              return proceed(new Error('Consistency violation: Should not have been able to find `stuff` key the 2nd time!!!  Must be a bug in our code.'));
+            }
+          }); //</Redis.getCachedValue>
+
+        }); //</Redis.destroyCachedValues>
+      }); //</Redis.getCachedValue>
+    }); //</Redis.cacheValue>
+  }//</during>
+  
+}, function afterwards(err) {
+  if (err) {
+    console.log('Attempted to do some stuff with redis, but encountered an error along the way:',err.stack);
+    return;
+  }//--•
+  
+  console.log('Successfully did some stuff with Redis!');
+});
+

--- a/machines/flush-cache.js
+++ b/machines/flush-cache.js
@@ -1,0 +1,82 @@
+module.exports = {
+
+
+  friendlyName: 'Flush cache',
+
+
+  description: 'Flush the cache, removing all data from it.',
+
+
+  cacheable: true,
+
+
+  inputs: {
+
+    connection: {
+      friendlyName: 'Connection',
+      description: 'An active connection.',
+      extendedDescription: 'The provided connection instance must still be active.  Only connection instances created by the `getConnection()` machine in the same driver are supported.',
+      example: '===',
+      required: true
+    },
+
+    meta: {
+      friendlyName: 'Meta (custom)',
+      description: 'Additional metadata to pass to the driver.',
+      extendedDescription: 'This input is not currently in use, but is reserved for driver-specific customizations in the future.',
+      example: '==='
+    }
+
+  },
+
+
+  exits: {
+
+    success: {
+      description: 'Cache was successfully flushed.',
+      outputVariableName: 'report',
+      outputDescription: 'The return value is true when the cache was successfully flushed.',
+      example: true
+    },
+
+    failed: {
+      description: 'The cache encountered an error while attempting to flush the cache.',
+      outputVariableName: 'report',
+      outputDescription: 'The `error` property is a JavaScript Error instance explaining the exact error.  The `meta` property is reserved for custom driver-specific extensions.',
+      example: {
+        error: '===',
+        meta: '==='
+      }
+    },
+
+    badConnection: require('../constants/badConnection.exit')
+
+  },
+  fn: function (inputs, exits) {
+    var isFunction = require('lodash.isfunction');
+    var isObject = require('lodash.isobject');
+
+    // Ducktype provided "connection" (which is actually a redis client)
+    if (!isObject(inputs.connection) || !isFunction(inputs.connection.end) || !isFunction(inputs.connection.removeAllListeners)) {
+      return exits.badConnection();
+    }
+
+    // Provided `connection` is a redis client.
+    var redisClient = inputs.connection;
+
+
+    redisClient.flushdb(function (err, result) {
+      if (err) {
+        return exits.failed(err);
+      }
+
+      // Finally, call exits.success().
+      // as per Redis docs, flushdb never fails and always return OK string
+      // https://redis.io/commands/flushdb
+      return exits.success(result === 'OK');
+
+    });
+  }
+
+
+};

--- a/machines/get-cached-value.js
+++ b/machines/get-cached-value.js
@@ -1,17 +1,17 @@
 module.exports = {
-//
-//
+
+
   friendlyName: 'Get cached value',
-//
-//
+
+
   description: 'Look up the cached value associated with the specified key.',
-//
-//
+
+
   sideEffects: 'cacheable',
-//
-//
+
+
   inputs: {
-//
+
     connection: {
       friendlyName: 'Connection',
       description: 'An active Redis connection.',
@@ -19,7 +19,7 @@ module.exports = {
       example: '===',
       required: true
     },
-//
+
     key: {
       friendlyName: 'Key',
       description: 'The unique key to look up.',
@@ -27,19 +27,19 @@ module.exports = {
       required: true,
       example: 'myNamespace.foo.bar_baz'
     },
-//
+
     meta: {
       friendlyName: 'Meta (custom)',
       description: 'Additional metadata to pass to the driver.',
       extendedDescription: 'This input is not currently in use, but is reserved for driver-specific customizations in the future.',
       example: '==='
     }
-//
+
   },
-//
-//
+
+
   exits: {
-//
+
     success: {
       description: 'Value was sucessfully fetched.',
       outputFriendlyName: 'Report',
@@ -49,7 +49,7 @@ module.exports = {
         meta: '==='
       }
     },
-//
+
     notFound: {
       description: 'No value exists under the specified key.',
       outputFriendlyName: 'Report',
@@ -58,9 +58,9 @@ module.exports = {
         meta: '==='
       }
     },
-//
+
     badConnection: require('../constants/badConnection.exit')
-//
+
   },
 
 
@@ -74,10 +74,13 @@ module.exports = {
     }
 
     // Provided `connection` is a redis client.
+    /**
+     * redisClient red
+     */
     var redisClient = inputs.connection;
 
 
-    redisClient.get(inputs.key, function (err, foundValue){
+    redisClient.get(inputs.key, function (err, foundValue) {
       if (err) {
         return exits.error(err);
       }
@@ -93,8 +96,8 @@ module.exports = {
       try {
         foundValue = JSON.parse(foundValue);
       }
-      //// Since we're in a callback, we need to use a try/catch to prevent
-      // throwing an uncaught exception and crashing the process.
+        //// Since we're in a callback, we need to use a try/catch to prevent
+        // throwing an uncaught exception and crashing the process.
       catch (e) {
         return exits.error(e);
       }

--- a/machines/get-connection.js
+++ b/machines/get-connection.js
@@ -82,16 +82,16 @@ module.exports = {
 
     // Build a local variable (`redisClientOptions`) to house a dictionary
     // of additional Redis client options that will be passed into createClient().
-    // (this is pulled from the `meta` mananger)
+    // (this is pulled from the `meta` manager)
     //
     // For a complete list of available options, see:
-    //  • https://github.com/NodeRedis/node_redis#options-is-an-object-with-the-following-possible-properties
+    //  • https://github.com/NodeRedis/node_redis#rediscreateclient
     var redisClientOptions = inputs.manager.meta || {};
 
     // Create Redis client
     var client;
     try {
-
+      // [redis:]//[[user][:password]@][host][:port][/db-number][?db=db-number[&password=bar[&option=value]]]
       client = redis.createClient(inputs.manager.connectionString, redisClientOptions);
     } catch (e) {
       // If a "TypeError" was thrown, it means something was wrong with

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "release-connection",
       "get-cached-value",
       "cache-value",
-      "destroy-cached-values"
+      "destroy-cached-values",
+      "flush-cache"
     ],
     "implements": {
       "connectable": "1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash.isfunction": "3.0.8",
     "lodash.isobject": "3.0.2",
     "machine": "^13.0.0-11",
-    "redis": "2.4.2"
+    "redis": "2.6.3"
   },
   "devDependencies": {
     "istanbul": "0.4.5",

--- a/tests/cache-value.test.js
+++ b/tests/cache-value.test.js
@@ -6,7 +6,6 @@ var Pack = require('../');
 var shouldProperlyStoreValue = require('./helpers/should-properly-store-value.test-helper');
 
 
-
 /**
  * Note: These tests should ideally not be redis-specific.
  * (that way we can reuse them for any driver implementing the "cache" interface layer)
@@ -14,20 +13,20 @@ var shouldProperlyStoreValue = require('./helpers/should-properly-store-value.te
 
 describe('cacheValue()', function (){
 
-// Used to hold manager and active connection throughout the tests below.
+  // Used to hold manager and active connection throughout the tests below.
   var manager;
   var connection;
-  // The keys to use during tests. Prefixed with `machinepack-redis.` so that 
+  // The keys to use during tests. Prefixed with `machinepack-cache.` so that
   // there is no key name clash with any other possible existing keys
-  var keysUsed = [12345, 'machinepack-redis.test1', 'machinepack-redis.test2', 'machinepack-redis.test3', 'machinepack-redis.test4', 'machinepack-redis.test5', 'machinepack-redis.test6', 'machinepack-redis.test7', 'machinepack-redis.test8'];
+  var keysUsed = [12345, 'machinepack-cache.test1', 'machinepack-cache.test2', 'machinepack-cache.test3', 'machinepack-cache.test4', 'machinepack-cache.test5', 'machinepack-cache.test6', 'machinepack-cache.test7', 'machinepack-cache.test8'];
 
-  //                                               _   _             
-  //                                              | | (_)            
-  // _ __   ___     ___ ___  _ __  _ __   ___  ___| |_ _  ___  _ __  
-  //| '_ \ / _ \   / __/ _ \| '_ \| '_ \ / _ \/ __| __| |/ _ \| '_ \ 
+  //                                               _   _
+  //                                              | | (_)
+  // _ __   ___     ___ ___  _ __  _ __   ___  ___| |_ _  ___  _ __
+  //| '_ \ / _ \   / __/ _ \| '_ \| '_ \ / _ \/ __| __| |/ _ \| '_ \
   //| | | | (_) | | (_| (_) | | | | | | |  __/ (__| |_| | (_) | | | |
   //|_| |_|\___/   \___\___/|_| |_|_| |_|\___|\___|\__|_|\___/|_| |_|
-  //                                                                 
+  //
   describe('with no connection', function (){
     it('should fail', function (done){
       Pack.cacheValue({
@@ -61,26 +60,36 @@ describe('cacheValue()', function (){
     // connection from it.
     before(function (done){
       Pack.createManager({
-        connectionString: 'redis://127.0.0.1:6379',
+        // 15 = non standard database for the unit tests
+        connectionString: 'redis://127.0.0.1:6379/15',
         meta: {
           password: 'qwer1234'
         }
       }).exec({
-        error: done,
+        error: function (err){
+          done(err);
+        },
         success: function (report){
           // Save reference to manager.
           manager = report.manager;
           Pack.getConnection({
             manager: manager
           }).exec({
-            error: done,
+            error: function (err){
+              done(new Error(JSON.stringify(err)));
+            },
+            failed: function (err){
+              done(new Error(JSON.stringify(err)));
+            },
             success: function (report){
               // Save reference to connection.
               connection = report.connection;
               // Now delete keys just to be safe.
-              Pack.destroyCachedValues({
+              Pack.flushCache({
                 connection: connection,
-                keys: keysUsed
+                meta: {
+                  db: 15 // non standard database for the unit tests
+                }
               }).exec(done);
             }
           });
@@ -270,26 +279,28 @@ describe('cacheValue()', function (){
     }); //</should handle ttl correctly>
 
 
-
     //  ┌─┐┌─┐┌┬┐┌─┐┬─┐
     //  ├─┤├┤  │ ├┤ ├┬┘
     //  ┴ ┴└   ┴ └─┘┴└─ooo
-    // Afterwards, destroy the keys that were set, and then also destroy the manager
+    // Afterwards, flush the cache, and then also destroy the manager
     // (which automatically releases any connections).
     after(function (done){
-      Pack.destroyCachedValues({
-        connection: connection,
-        keys: keysUsed
-      }).exec(function (err){
-        // If there is an error deleting keys, log it but don't stop
-        // (we need to be sure and destroy the manager)
-        if (err) {
-          console.error('ERROR: Could not destroy keys in test cleanup.  Details:\n', err);
-        }
-        Pack.destroyManager({
-          manager: manager
-        }).exec(done);
-      });
+      if (connection) {
+        Pack.flushCache({
+          connection: connection
+        }).exec(function (err){
+          // If there is an error flushing the cache, log it but don't stop
+          // (we need to be sure and destroy the manager)
+          if (err) {
+            console.error('ERROR: Could not flush the cache in test cleanup.  Details:\n', err);
+          }
+          Pack.destroyManager({
+            manager: manager
+          }).exec(done);
+        });
+      } else {
+        done();
+      }
     }); //</after>
 
 

--- a/tests/flush-cache.test.js
+++ b/tests/flush-cache.test.js
@@ -1,0 +1,90 @@
+/**
+ * Module dependencies
+ */
+
+var Pack = require('../');
+var shouldProperlyStoreValue = require('./helpers/should-properly-store-value.test-helper');
+
+/**
+ * Note: These tests should ideally not be redis-specific.
+ * (that way we can reuse them for any driver implementing the "cache" interface layer)
+ */
+
+describe('flushCache()', function (){
+
+  // Used to hold manager and active connection throughout the tests below.
+  var manager;
+  var connection;
+
+  //                                               _   _
+  //                                              | | (_)
+  // _ __   ___     ___ ___  _ __  _ __   ___  ___| |_ _  ___  _ __
+  //| '_ \ / _ \   / __/ _ \| '_ \| '_ \ / _ \/ __| __| |/ _ \| '_ \
+  //| | | | (_) | | (_| (_) | | | | | | |  __/ (__| |_| | (_) | | | |
+  //|_| |_|\___/   \___\___/|_| |_|_| |_|\___|\___|\__|_|\___/|_| |_|
+  //
+  describe('with no connection', function (){
+    it('should fail', function (done){
+      Pack.flushCache({
+        connection: {}
+      }).exec({
+        error: done,
+        badConnection: function (){
+          return done();
+        },
+        success: function (){
+          return done(new Error('Expecting `badConnection` exit'));
+        }
+      });
+    });
+  });
+
+
+  //  ╔╗ ╔═╗╔═╗╦╔═╗  ╦ ╦╔═╗╔═╗╔═╗╔═╗
+  //  ╠╩╗╠═╣╚═╗║║    ║ ║╚═╗╠═╣║ ╦║╣
+  //  ╚═╝╩ ╩╚═╝╩╚═╝  ╚═╝╚═╝╩ ╩╚═╝╚═╝
+  describe('with connection', function (){
+
+    it('should work', function (done){
+      Pack.createManager({
+        // 15 = non standard database for the unit tests
+        connectionString: 'redis://127.0.0.1:6379/15',
+        meta: {
+          password: 'qwer1234'
+        }
+      }).exec({
+        error: function (err){
+          done(new Error(JSON.stringify(err)));
+        },
+        success: function (report){
+          // Save reference to manager.
+          manager = report.manager;
+          Pack.getConnection({
+            manager: manager
+          }).exec({
+            error: function (err){
+              done(new Error(JSON.stringify(err)));
+            },
+            failed: function (err){
+              done(new Error(JSON.stringify(err)));
+            },
+            success: function (report){
+              // Save reference to connection.
+              connection = report.connection;
+              Pack.flushCache({
+                connection: connection,
+                meta: {
+                  db: 15 // non standard database for the unit tests
+                }
+              }).exec(done);
+            }
+          });
+        }
+      });
+    }); //</it should work>
+
+  }); //</with connection>
+
+});
+
+

--- a/tests/get-connection.test.js
+++ b/tests/get-connection.test.js
@@ -20,7 +20,8 @@ describe('getConnection()', function (){
 
     it('should connect with a password', function (done){
       Pack.createManager({
-        connectionString: 'redis://127.0.0.1:6379'
+        // 15 = non standard database for the unit tests
+        connectionString: 'redis://127.0.0.1:6379/15'
       }).exec({
         error: done,
         success: function (result){
@@ -29,7 +30,12 @@ describe('getConnection()', function (){
           Pack.getConnection({
             manager: manager
           }).exec({
-            error: done,
+            error: function (err){
+              done(new Error(JSON.stringify(err)));
+            },
+            failed: function (err){
+              done(new Error(JSON.stringify(err)));
+            },
             success: function (){
               done();
             }
@@ -40,7 +46,8 @@ describe('getConnection()', function (){
 
     it('should fail to connect to an invalid port', function (done){
       Pack.createManager({
-        connectionString: 'redis://127.0.0.1:9999',
+        // 15 = non standard database for the unit tests
+        connectionString: 'redis://127.0.0.1:9999/15',
         meta: {
           connect_timeout: 1000,
           retry_strategy: function (){

--- a/tests/helpers/should-properly-store-value.test-helper.js
+++ b/tests/helpers/should-properly-store-value.test-helper.js
@@ -19,7 +19,7 @@ var Pack = require('../../');
  * @param  {Function} done
  */
 
-module.exports = function shouldProperlyStoreValue (opts, done){
+module.exports = function shouldProperlyStoreValue(opts, done){
   Pack.cacheValue({
     connection: opts.connection,
     key: opts.key,


### PR DESCRIPTION
1. Adds flush-cache
2. Removes // placeholders
3. Fixes references to some URLs
4. Made all tests use database #15
5. Replaced use of destroyKeys with flushCache on before and after tests
6. Commented what options can be added to a redis connection string
7. Moved the example in README to a separate file in an examples folder.